### PR TITLE
led bug fix

### DIFF
--- a/Library/ARGB.c
+++ b/Library/ARGB.c
@@ -739,13 +739,13 @@ hsv_t rgb2hsv_approximate(const rgb_t rgb)
 
 hsv_t argb_get_hue(uint16_t i)
 {
-    rgb_t rgb = {.r=rgb_buf[i], .g=rgb_buf[i+1], .b=rgb_buf[i+2]};
+    rgb_t rgb = {.r=rgb_buf[(3*i)], .g=rgb_buf[(3*i)+1], .b=rgb_buf[(3*i)+2]};
     return rgb2hsv_approximate(rgb);
 }
 
 rgb_t argb_get_rgb(uint16_t i)
 {
-    rgb_t rgb = {.r=rgb_buf[i], .g=rgb_buf[i+1], .b=rgb_buf[i+2]};
+    rgb_t rgb = {.r=rgb_buf[(3*i)], .g=rgb_buf[(3*i)+1], .b=rgb_buf[(3*i)+2]};
     return rgb;
 }
 

--- a/Library/ARGB.h
+++ b/Library/ARGB.h
@@ -29,10 +29,9 @@
  * @addtogroup User_settings
  * @brief LED & Timer's settings
  * @{
- */
-
-
-#define NUM_PIXELS NUM_LEDS ///< Pixel quantity
+ */ 
+#define NUM_PIXELS (NUM_LEDS + 1) ///<- Pixel quantity
+// The `+1` above is an extra byte used to give the DMA transfer a bit of extra time which ensures the last LED's RGB-PWM data gets transfered and then displayed correctly.
 
 #define USE_GAMMA_CORRECTION 1 ///< Gamma-correction should fix red&green, try for yourself
 

--- a/Library/ARGB.h
+++ b/Library/ARGB.h
@@ -15,6 +15,7 @@
 /**
  * Significant history (date, user, job code, action):
  * - 2022-10-18, Dylan Arrabito  <darrabito@carngeigerobotics.com>, IRAD.8015.1, Greatly modified to support ChibiOS.
+ * - 2023-06-08, Morgan Visnesky <mvisnesky@carnegierobotics.com>, 2036.05.01, Fix for missing blue channel value for last LED of ws2812 strip.
  */
 
 #pragma once


### PR DESCRIPTION
Description:
Fixes incorrect color for the last LED on ws2812 LED strip.

Details:
After checking contents of all buffers (LED, PWM, etc.), all contained the correct LED color channel data, despite that the incorrect color persisted. The last LED was not receiving the very last data byte containing the blue color channel. We believe this issue was timing related: the DMA transfer ended before all contents in the PWM buffer was transferred.

Solution:
Added an extra empty byte to the PWM buffer to allow a slight bit of extra time for all the non-empty data to be transferred correctly. After testing this proved to remedy the bug without causing any other unexpected issues.
